### PR TITLE
Override more functions from the FreeBSD provider.  

### DIFF
--- a/libraries/pkgng.rb
+++ b/libraries/pkgng.rb
@@ -29,6 +29,19 @@ class Chef
           pkg_info.stdout[/^#{package_name}-(.*)/, 1]
         end
 
+        def ports_candidate_version
+          pkg_info = shell_out!("pkg search #{package_name}", :env => nil, :returns => [0, 70])
+          pkg_info.stdout[/^#{package_name}-(.*)/, 1]
+        end
+
+        def latest_link_name
+          @new_resource.package_name
+        end
+
+        def package_name
+          @new_resource.package_name
+        end
+
         def install_package(name, version)
           unless @current_resource.version
             case @new_resource.source

--- a/libraries/pkgng.rb
+++ b/libraries/pkgng.rb
@@ -30,8 +30,21 @@ class Chef
         end
 
         def ports_candidate_version
-          pkg_info = shell_out!("pkg search #{package_name}", :env => nil, :returns => [0, 70])
-          pkg_info.stdout[/^#{package_name}-(.*)/, 1]
+          pkg_search = shell_out!("pkg search #{package_name}", :env => nil, :returns => [0, 70])
+          pkg_search.stdout[/^#{package_name}-(.*)/, 1]
+        end
+
+        def load_current_resource
+          @current_resource.package_name(@new_resource.package_name)
+
+          @current_resource.version(current_installed_version)
+          Chef::Log.debug("#{@new_resource} current version is #{@current_resource.version}") if @current_resource.version
+
+          @candidate_version = ports_candidate_version
+
+          Chef::Log.debug("#{@new_resource} ports candidate version is #{@candidate_version}") if @candidate_version
+
+          @current_resource
         end
 
         def latest_link_name


### PR DESCRIPTION
I was having trouble installing openjdk.  It kept complaining that the port didn't exist.
Overriding these parent functions let me install the package.